### PR TITLE
Revert "fix(package.xml): add missing dep on robosense_gazebo_plugins"

### DIFF
--- a/robosense_description/package.xml
+++ b/robosense_description/package.xml
@@ -17,6 +17,5 @@
 
   <exec_depend>urdf</exec_depend>
   <exec_depend>xacro</exec_depend>
-  <exec_depend>robosense_gazebo_plugins</exec_depend>
 
 </package>


### PR DESCRIPTION
This reverts commit 1f4a2cbc989b52319a8d10112bcaa99b482b3cbe.

I ran into the issue that simulator dependencies are installed on a robot when the description is installed. To avoid this, I removed the simulator dependency in the description pkg.